### PR TITLE
(fix) adds BunJS support

### DIFF
--- a/lib/CombUUID.js
+++ b/lib/CombUUID.js
@@ -22,13 +22,11 @@ class CombUUID {
         const variant = 'b';
 
         // random
-        const bytes = Buffer.alloc(18);
-        crypto.randomFillSync(bytes);
-        const bytes_hex = bytes.toString('hex');
-        const r1 = bytes_hex.substring(0, 3);
-        const r2 = bytes_hex.substring(3, 6);
-        const r3 = bytes_hex.substring(6, 18);
-
+        const bytes = crypto.randomBytes(18).toString("hex");
+        const r1 = bytes.substring(0,3);
+        const r2 = bytes.substring(3,6);
+        const r3 = bytes.substring(6,18);
+        
         return `${ts1}-${ts2}-${version}${r1}-${variant}${r2}-${r3}`;
     }
 


### PR DESCRIPTION
`randomFillSync` gives errors when the BunJS runtime is used. Works in the latest version of NodeJS (v18.2.0).

<img width="893" alt="Screen Shot 2022-10-16 at 3 56 05 PM" src="https://user-images.githubusercontent.com/50812322/196059023-1440ce79-21c3-4db0-933a-4d93d8da8a48.png">
<img width="893" alt="Screen Shot 2022-10-16 at 3 54 58 PM" src="https://user-images.githubusercontent.com/50812322/196059028-14e8f710-3c0e-45de-9081-6361c191295f.png">
